### PR TITLE
Added gitignore; bugfix in example script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# Python packaging 
+**/__pycache__
+*.egg-info/
+
+# Files made by the example script
+test_prediction/

--- a/example.py
+++ b/example.py
@@ -20,6 +20,7 @@ from boltz.main import (
     download_boltz1 as download,
 )
 from boltz.model.models.boltz1 import Boltz1
+from boltz.data.types import Manifest
 
 import joltz
 
@@ -77,10 +78,11 @@ manifest = process_inputs(
     msa_server_url="https://api.colabfold.com",
     msa_pairing_strategy="greedy",
 )
+
 # Load processed data
 processed_dir = out_dir / "processed"
 processed = BoltzProcessedInput(
-    manifest=manifest.load(processed_dir / "manifest.json"),
+    manifest=Manifest.load(processed_dir / "manifest.json"),
     targets_dir=processed_dir / "structures",
     msa_dir=processed_dir / "msa",
 )


### PR DESCRIPTION
I was unable to run the example script with a more recent version of Manifest, as process inputs does not return anything, leading to "manifest" in line 83 being Nonetype.  I fixed this by calling the classmethod from the Manifest class directly.

Also, I took the liberty of adding a .gitignore to avoid the folder generated by the example script from being accidentally committed.